### PR TITLE
Promote common Maven configuration to parent pom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: java
+
+jdk:
+  - oraclejdk8
+
+# Run on container-based infrastructure
+sudo: false
+
+cache:
+  directories:
+    - ${HOME}/.m2/repository
+
+before_install:
+  - if [ ! -z "${GPG_SECRET_KEYS}" ]; then echo ${GPG_SECRET_KEYS} | base64 --decode | ${GPG_EXECUTABLE} --import; fi
+  - if [ ! -z "${GPG_OWNERTRUST}" ]; then echo ${GPG_OWNERTRUST} | base64 --decode | ${GPG_EXECUTABLE} --import-ownertrust; fi
+
+install:
+  - mvn --settings .travis/settings.xml --show-version dependency:resolve
+  - mvn --settings .travis/settings.xml --show-version dependency:resolve-plugins
+
+script:
+  - mvn --batch-mode --settings .travis/settings.xml --show-version test
+
+deploy:
+  - provider: script
+    script: .travis/deploy-lib.sh
+    skip_cleanup: true
+    on:
+      repo: spals/midas
+      branch: master
+      jdk: oraclejdk8
+  - provider: script
+    script: .travis/deploy-lib.sh
+    skip_cleanup: true
+    on:
+      repo: spals/midas
+      tags: true
+      jdk: oraclejdk8

--- a/.travis/deploy-lib.sh
+++ b/.travis/deploy-lib.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+cd `dirname $0`/..
+
+if [ -z "${SONATYPE_USERNAME}" ]
+then
+    echo "error: please set SONATYPE_USERNAME and SONATYPE_PASSWORD environment variable"
+    exit 1
+fi
+
+if [ -z "${SONATYPE_PASSWORD}" ]
+then
+    echo "error: please set SONATYPE_PASSWORD environment variable"
+    exit 1
+fi
+
+if [ ! -z "${TRAVIS_TAG}" ]
+then
+    echo "on a tag -> set pom.xml <version> to ${TRAVIS_TAG}"
+    mvn --settings .travis/settings.xml org.codehaus.mojo:versions-maven-plugin:2.1:set -DgenerateBackupPoms=false -DnewVersion=${TRAVIS_TAG} 1>/dev/null 2>/dev/null
+    mvn --batch-mode --settings .travis/settings.xml --update-snapshots clean deploy -Ddeploy -DskipTests
+
+    # Create new SNAPSHOT version by incrementing the patch
+    TRAVIS_TAG_ARRAY=( ${TRAVIS_TAG//./ } )
+    ((TRAVIS_TAG_ARRAY[-1]++))
+
+    function join { local IFS="$1"; shift; echo "$*"; }
+    NEW_SNAPSHOT_VERSION="$(join . ${TRAVIS_TAG_ARRAY[@]})-SNAPSHOT"
+
+    echo "setting new SNAPSHOT version to ${NEW_SNAPSHOT_VERSION}"
+    mvn --settings .travis/settings.xml org.codehaus.mojo:versions-maven-plugin:2.1:set -DgenerateBackupPoms=false -DnewVersion=${NEW_SNAPSHOT_VERSION} 1>/dev/null 2>/dev/null
+    git commit -a -m "[ci skip] Bump version to ${NEW_SNAPSHOT_VERSION}"
+    git push origin master
+else
+    echo "not on a tag -> keep snapshot version in pom.xml"
+    mvn --batch-mode --settings .travis/settings.xml --update-snapshots clean deploy -Ddeploy -DskipTests
+fi

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -11,4 +11,5 @@
             <password>${env.SONATYPE_PASSWORD}</password>
         </server>
     </servers>
+
 </settings>

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -1,0 +1,14 @@
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <!-- Maven Central Deployment -->
+            <id>ossrh</id>
+            <username>${env.SONATYPE_USERNAME}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -145,47 +145,56 @@
         </dependencies>
     </dependencyManagement>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>${maven-gpg-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+    <profile>
+        <id>deploy</id>
+        <activation>
+            <property>
+                <name>deploy</name>
+            </property>
+        </activation>
 
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${nexus-staging-maven-plugin.version}</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+        <properties>
+            <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+            <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+        </properties>
+
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${maven-gpg-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${nexus-staging-maven-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <serverId>ossrh</serverId>
+                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
 
     <distributionManagement>
         <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
+            <id>ossrh</id>
             <name>Sonatype Nexus snapshot repository</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
-        <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Sonatype Nexus release repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
     </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -145,50 +145,52 @@
         </dependencies>
     </dependencyManagement>
 
-    <profile>
-        <id>deploy</id>
-        <activation>
-            <property>
-                <name>deploy</name>
-            </property>
-        </activation>
+    <profiles>
+        <profile>
+            <id>deploy</id>
+            <activation>
+                <property>
+                    <name>deploy</name>
+                </property>
+            </activation>
 
-        <properties>
-            <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
-            <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
-        </properties>
+            <properties>
+                <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+            </properties>
 
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>${maven-gpg-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>sign-artifacts</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>sign</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
 
-                <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>${nexus-staging-maven-plugin.version}</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </build>
-    </profile>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>${nexus-staging-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION
@thespags 

Pretty much what the subject says. I want to limit the amount of copy and pasting we're doing between projects. Everything can just inherit from the parent pom.