### PR TITLE
Scala profile

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2016, spals
+Copyright (c) 2016-2017, spals
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <jackson.version>2.8.7</jackson.version>
         <mockito.version>2.2.26</mockito.version>
         <scala-java8-compat.version>0.8.0</scala-java8-compat.version>
+        <scalapb.version>0.5.47</scalapb.version>
         <scalatest.version>3.0.1</scalatest.version>
         <slf4j.version>1.7.21</slf4j.version>
         <testng.version>6.9.10</testng.version>
@@ -166,6 +167,16 @@
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-servlet</artifactId>
                 <version>${guice.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.trueaccord.scalapb</groupId>
+                <artifactId>scalapbc_${scala.version}</artifactId>
+                <version>${scalapb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.trueaccord.scalapb</groupId>
+                <artifactId>scalapb-runtime_${scala.version}</artifactId>
+                <version>${scalapb.version}</version>
             </dependency>
             <dependency>
                 <groupId>eu.codearte.catch-exception</groupId>
@@ -286,15 +297,6 @@
                     <configuration>
                         <scalaVersion>${scala-library.version}</scalaVersion>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>compile</goal>
-                                <goal>add-source</goal>
-                                <goal>testCompile</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
 
                 <plugin>
@@ -414,6 +416,25 @@
                     </plugin>
 
                     <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-scala-sources</id>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>attach-scala-javadocs</id>
+                                <goals>
+                                    <goal>doc-jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>${maven-gpg-plugin.version}</version>
@@ -438,6 +459,174 @@
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>generateProtobufJava</id>
+            <activation>
+                <file>
+                    <exists>src/main/protobuf/generateJava.marker</exists>
+                </file>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.os72</groupId>
+                        <artifactId>protoc-jar-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-protobuf-java</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <type>java</type>
+                                    <outputDirectorySuffix>protobuf/java</outputDirectorySuffix>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>generateProtobufScala</id>
+            <activation>
+                <file>
+                    <exists>src/main/protobuf/generateScala.marker</exists>
+                </file>
+            </activation>
+
+            <properties>
+                <scalapbc.download.outputDirectory>${project.build.directory}</scalapbc.download.outputDirectory>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>download-scalapbc</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${scalapbc.download.outputDirectory}</outputDirectory>
+                                    <url>https://github.com/scalapb/ScalaPB/releases/download/v${scalapb.version}/scalapbc-${scalapb.version}.zip</url>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unzip-scalapbc</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <unzip src="${scalapbc.download.outputDirectory}/scalapbc-${scalapb.version}.zip"
+                                               dest="${scalapbc.download.outputDirectory}"/>
+                                        <!-- Make scalapbc executable -->
+                                        <chmod file="${scalapbc.download.outputDirectory}/scalapbc-${scalapb.version}/bin/scalapbc"
+                                               perm="755"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>com.github.os72</groupId>
+                        <artifactId>protoc-jar-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-protobuf-scala</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <type>scala</type>
+                                    <outputDirectorySuffix>protobuf/scala</outputDirectorySuffix>
+                                    <protocCommand>${scalapbc.download.outputDirectory}/scalapbc-${scalapb.version}/bin/scalapbc</protocCommand>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>scalaCompile</id>
+            <activation>
+                <file>
+                    <exists>src/main/scala</exists>
+                </file>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>scalaTestCompile</id>
+            <activation>
+                <file>
+                    <exists>src/test/scala</exists>
+                </file>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Moving scala plugin executions from `<pluginManagement/>` to various `<profiles/>`. This provides more granular control over when scala goals are executed and when they are not.