### PR TITLE
Add build profiles for code coverage reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,20 +331,6 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${jacoco-maven-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>default-prepare-agent</id>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>default-prepare-agent-integration</id>
-                            <goals>
-                                <goal>prepare-agent-integration</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
 
                 <plugin>
@@ -636,13 +622,54 @@
         </profile>
 
         <profile>
-            <id>runJacoco</id>
+            <id>prepareJacoco</id>
             <activation>
                 <file>
                     <exists>src/test</exists>
                 </file>
                 <property>
-                    <name>runJacoco</name>
+                    <name>runReporting</name>
+                </property>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jacoco-prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration</id>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>jacoco-merge</id>
+                                <goals>
+                                    <goal>merge</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>runJacocoReport</id>
+            <activation>
+                <file>
+                    <exists>jacocoReport.marker</exists>
+                </file>
+                <property>
+                    <name>runReporting</name>
                 </property>
             </activation>
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <docker-maven-plugin.version>0.21.0</docker-maven-plugin.version>
         <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-failsafe-plugin.version>2.8.1</maven-failsafe-plugin.version>
@@ -307,6 +308,26 @@
                         <source>${java.version}</source>
                         <target>${java.version}</target>
                     </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>default-prepare-agent-integration</id>
+                            <goals>
+                                <goal>prepare-agent-integration</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
 
                 <plugin>
@@ -590,6 +611,49 @@
                                 <goals>
                                     <goal>compile</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>runJacoco</id>
+            <activation>
+                <file>
+                    <exists>src/test</exists>
+                </file>
+                <property>
+                    <name>runJacoco</name>
+                </property>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jacoco-report-aggregate</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report-aggregate</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes>
+                                        <!-- Exclude annotations -->
+                                        <exclude>**/annotations/**/*</exclude>
+                                        <!-- Exclude generated FreeBuilder beans -->
+                                        <exclude>**/*_Builder*</exclude>
+                                        <!-- Exclude generated AutoValue beans -->
+                                        <exclude>**/*AutoValue_*</exclude>
+                                        <!-- Exclude generated Protobuf beans -->
+                                        <exclude>**/protobuf/java/**/*</exclude>
+                                        <exclude>**/protobuf/scala/**/*</exclude>
+                                    </excludes>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,24 @@
                         </execution>
                     </executions>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven-javadoc-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${maven-gpg-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${nexus-staging-maven-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -404,7 +422,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven-javadoc-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -437,7 +454,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -452,7 +468,6 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${nexus-staging-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
     </licenses>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <!-- Java version -->
         <java.version>1.8</java.version>
 
@@ -91,6 +93,7 @@
 
         <!-- Plugin versions -->
         <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
+        <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <docker-maven-plugin.version>0.21.0</docker-maven-plugin.version>
         <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
@@ -390,6 +393,12 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>${coveralls-maven-plugin.version}</version>
                 </plugin>
 
                 <plugin>
@@ -697,7 +706,39 @@
                                         <exclude>**/protobuf/java/**/*</exclude>
                                         <exclude>**/protobuf/scala/**/*</exclude>
                                     </excludes>
+                                    <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- NOTE: Defined after runJacocoReport so that Jacoco execution happens first -->
+        <profile>
+            <id>runCoverallsReport</id>
+            <activation>
+                <file>
+                    <exists>coverallsReport.marker</exists>
+                </file>
+                <property>
+                    <name>runReporting</name>
+                </property>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eluder.coveralls</groupId>
+                        <artifactId>coveralls-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>coveralls-report</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -715,6 +756,24 @@
 
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-scala-source</id>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/main/scala</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                     <plugin>
                         <groupId>net.alchim31.maven</groupId>
                         <artifactId>scala-maven-plugin</artifactId>
@@ -740,6 +799,24 @@
 
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-scala-source</id>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/scala</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                     <plugin>
                         <groupId>net.alchim31.maven</groupId>
                         <artifactId>scala-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <auto-value.version>1.3</auto-value.version>
         <catch-exception.version>2.0.0-ALPHA-1</catch-exception.version>
         <freebuilder.version>1.14.1</freebuilder.version>
+        <groovy.version>2.4.12</groovy.version>
         <guava.version>20.0</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>2.0.0.0</hamcrest.version>
@@ -93,6 +94,7 @@
         <docker-maven-plugin.version>0.21.0</docker-maven-plugin.version>
         <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+        <gmavenplus-plugin.version>1.5</gmavenplus-plugin.version>
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
@@ -265,6 +267,21 @@
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>${maven-antrun-plugin.version}</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.gmavenplus</groupId>
+                    <artifactId>gmavenplus-plugin</artifactId>
+                    <version>${gmavenplus-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.groovy</groupId>
+                            <artifactId>groovy-all</artifactId>
+                            <version>${groovy.version}</version>
+                            <scope>runtime</scope>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+
 
                 <plugin>
                     <groupId>com.googlecode.maven-download-plugin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -659,12 +659,6 @@
                                     <goal>prepare-agent-integration</goal>
                                 </goals>
                             </execution>
-                            <execution>
-                                <id>jacoco-merge</id>
-                                <goals>
-                                    <goal>merge</goal>
-                                </goals>
-                            </execution>
                         </executions>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
@thespags 

Adding build profiles to support code coverage reports. This uses the [Jacoco maven plugin](http://www.eclemma.org/jacoco/trunk/doc/maven.html) to get the test coverage reports. And then the [Coveralls maven plugin](https://github.com/trautonen/coveralls-maven-plugin) to post the reports publicly to [Coveralls](https://coveralls.io/).

The whole thing is controlled by the `-DrunReporting` option during a Maven build (this will be set in a Travis build file):

```bash
$ mvn verify -DrunReporting
```